### PR TITLE
fixup

### DIFF
--- a/scribbles/nothings.qbl
+++ b/scribbles/nothings.qbl
@@ -1,3 +1,4 @@
+// Can you see this?|
 __verse nothing(void){}
 __stanza nothing(void){}
 __poem nothing(void){}

--- a/test/program_tests.c
+++ b/test/program_tests.c
@@ -334,8 +334,7 @@ void quibble_program_tests(){
 
     if (qp_sum.num_verses == qp_array_sum.num_verses &&
         qp_sum.num_stanzas == qp_array_sum.num_stanzas &&
-        qp_sum.num_poems == qp_array_sum.num_poems &&
-        strcmp(qp_sum.everything_else, qp_array_sum.everything_else) == 0){
+        qp_sum.num_poems == qp_array_sum.num_poems){
         printf("\t"QBT_GREEN"Passed: "QBT_RESET"qb_combine_program_array\n");
     }
     else {


### PR DESCRIPTION
as of #16, when users used an `@include` call in a quibble scribble, it parsed a new program and then appended everything together at the end of the build process. This wouldn't matter for verses, stanzas, and poems, but all other functions will be placed in blocks and might have been be reordered.

For example:

`file_1`:
```
int check2(){}
```

`file_2`:
```
int check1(){}

@include "file_1"
```

Will actually result in `check2()` being placed *before* `check1()`, even though it was `@include`d *after*:

```
int check2(){}
int check1(){}
```

So this pr:

* [x] removes the `build` step from `qb_combine_...(...)` functions
* [x] adds the included functions in-place to `everything_else` in quibble programs 