### PR TITLE
Adding keywords to poems

### DIFF
--- a/include/io.h
+++ b/include/io.h
@@ -21,6 +21,7 @@ char *qb_find_path(char *filename);
 char *qb_config_file(char *path);
 
 size_t qb_find_type_size(char *type);
+void *qb_string_to_void(char *type, char *value);
 
 // String Manipulation
 bool qb_is_space(char a);

--- a/include/quibble_args.h
+++ b/include/quibble_args.h
@@ -32,6 +32,9 @@ quibble_kwarg *qb_parse_kwargs(char *config, int num_entries);
 
 int qb_find_arg_index(quibble_arg *arg, int n, char *variable);
 int qb_find_kwarg_index(quibble_kwarg *qk, int n, char *variable);
+int qb_find_any_index(quibble_arg *args, int n,
+                      quibble_kwarg *kwargs, int k_n,
+                      char *variable);
 
 // prologue
 char *qb_create_prologue(char *config, char *name,

--- a/include/quibble_program.h
+++ b/include/quibble_program.h
@@ -34,6 +34,8 @@ typedef struct{
 typedef struct{
     quibble_arg *args;
     int num_args;
+    quibble_kwarg *kwargs;
+    int num_kwargs;
     char *body;
     char *name;
 } quibble_poem;

--- a/src/io.c
+++ b/src/io.c
@@ -26,6 +26,9 @@ quibble_pixel *qb_create_pixel_array(int height, int width){
     return qpa;
 }
 
+void *qb_string_to_void(char *type, char *value){
+}
+
 size_t qb_find_type_size(char *type){
 
     if (type == NULL){

--- a/src/quibble_args.c
+++ b/src/quibble_args.c
@@ -147,11 +147,41 @@ int qb_find_number_of_kwargs(char *config){
 
 }
 
+int qb_find_any_index(quibble_arg *args, int n,
+                      quibble_kwarg *kwargs, int k_n,
+                      char *variable){
+
+    if (n <= 0 && k_n <= 0){
+        return -1;
+    }
+
+    for (int i = 0; i < n; ++i){
+        if (strcmp(args[i].variable, variable) == 0){
+            return i;
+        }
+    }
+
+    for (int i = 0; i < k_n; ++i){
+        if (strcmp(kwargs[i].variable, variable) == 0){
+            if (n > 0){
+                return i+n;
+            }
+            else{
+                return i;
+            }
+        }
+    }
+
+    fprintf(stderr, "%s is not an argument or keyword argument!\n", variable);
+    exit(1);
+
+
+}
+
 int qb_find_arg_index(quibble_arg *qa, int n, char *variable){
     if (n <= 0){
         return -1;
     }
-
 
     for (int i = 0; i < n; ++i){
         if (strcmp(qa[i].variable, variable) == 0){

--- a/src/quibble_program.c
+++ b/src/quibble_program.c
@@ -742,6 +742,17 @@ void qb_configure_program(quibble_program *qp, int platform, int device){
     for (int i = 0; i < qp->num_poems; ++i){
 
         kernels[i] = clCreateKernel(qp->program, qp->poem_list[i].name, &err);
+        if (qp->poem_list[i].num_kwargs > 0){
+            for (int j = 0; j < qp->poem_list[i].num_kwargs; ++j){
+                void *data = qb_string_to_void(
+                    qp->poem_list[i].kwargs[j].type,
+                    qp->poem_list[i].kwargs[j].value
+                );
+                qb_set_arg(qp, qp->poem_list[i].name,
+                           qp->poem_list[i].kwargs[j].variable, 
+                           data);
+            }
+        }
         cl_check(err);
     }
 
@@ -777,8 +788,10 @@ void qb_set_arg(quibble_program *qp, char *poem, char *arg, void *data){
 
     qb_find_type_arg(arg, &type, &variable);
 
-    int arg_index = qb_find_arg_index(qp->poem_list[poem_index].args,
+    int arg_index = qb_find_any_index(qp->poem_list[poem_index].args,
                                       qp->poem_list[poem_index].num_args,
+                                      qp->poem_list[poem_index].kwargs,
+                                      qp->poem_list[poem_index].num_kwargs,
                                       variable);
 
     size_t object_size = qb_find_type_size(type);


### PR DESCRIPTION
After #4, users have the ability to specify keywords in both verses and stanzas, but not poems.

This is because the poems ultimately transform into kernels and keywords are tricky to implement in C (I guess you could do some variadic tricks, but it's not worth figuring out at this time.

Long story short, there are advantages to allowing users to set keywords for poems. These could be set automatically when kernels are configured, so the user doesn't need to manually set the arguments.

The problem is that I cannot find a way to support all keywords. I have attached a simple sketch that does most of the work for simple keywords (let's say `a = 5`), but it is missing the translation from `'5'` (a `char`) to a `void *` necessary for OpenCL. This is doable and was actually mainly done in https://github.com/leios/quibble/pull/4/commits/5a4179835e6d5c0fe8b905dea17fec5a5ba96472#diff-51ed3eaef734d969a6896d213bba2507fd36aad88a28207bdf2726916aa525c8L97.

The problem is kwargs like `a = 5*x`. This poses 2 problems:
1. What is `x`? Where is it defined? In some random C code?
2. How do I parse `5*x` in the simple method used above?

So long-story short, kwargs for poems are half-baked at best, but there's probably a good way to do this if I think about it a bit.