### PR TITLE
adding void data and different color types

### DIFF
--- a/include/io.h
+++ b/include/io.h
@@ -24,7 +24,7 @@ typedef struct {
 } quibble_color_rgb888;
 
 typedef struct {
-    void *colors;
+    void *host_data;
     unsigned char *output_array;
     int color_type;
     int height;
@@ -37,6 +37,7 @@ unsigned char qb_color_clamp(float value,
                              float max_value);
 quibble_color_rgba8888 qb_zero_color_rgba8888(void);
 quibble_color_rgb888 qb_zero_color_rgb888(void);
+
 quibble_color_rgba8888 qb_color_rgba8888(float red,
                                          float green,
                                          float blue,

--- a/src/io.c
+++ b/src/io.c
@@ -73,7 +73,6 @@ quibble_color_rgb888 qb_color_rgb888(float red, float green, float blue){
     return qp;
 }
 
-
 int qb_get_color_size(int color_type){
     if (color_type == RGBA8888){
         return 4;
@@ -99,18 +98,18 @@ quibble_pixels qb_create_blank_pixel_array(int width,
 
     qps.color_type = color_type;
     int color_size = qb_get_color_size(color_type);
-    qps.colors =
+    qps.host_data =
         (void *)malloc(sizeof(unsigned char *)*color_size*width*height);
 
     if (color_type == RGBA8888){
-        quibble_color_rgba8888 *vals = (quibble_color_rgba8888 *)qps.colors;
+        quibble_color_rgba8888 *vals = (quibble_color_rgba8888 *)qps.host_data;
         for (int i = 0; i < width * height; ++i){
             vals[i] = qb_zero_color_rgba8888();
         }
     }
 
     else if (color_type == RGB888){
-        quibble_color_rgb888 *vals = (quibble_color_rgb888 *)qps.colors;
+        quibble_color_rgb888 *vals = (quibble_color_rgb888 *)qps.host_data;
         for (int i = 0; i < width * height; ++i){
             vals[i] = qb_zero_color_rgb888();
         }
@@ -125,7 +124,7 @@ quibble_pixels qb_create_pixel_array_from_file(char *filename,
                                                int height,
                                                int color_type){
     quibble_pixels qps = qb_create_blank_pixel_array(width, height, color_type);
-    qps.colors = qb_read_file(filename, width, height, color_type);
+    qps.host_data = qb_read_file(filename, width, height, color_type);
     return qps;
 }
 
@@ -215,7 +214,7 @@ void qb_write_png_file(char *filename, quibble_pixels qps){
                    qps.width,
                    qps.height,
                    qps.color_type,
-                   qps.colors,
+                   qps.host_data,
                    qps.width*qb_get_color_size(qps.color_type));
 }
 
@@ -224,7 +223,7 @@ void qb_write_bmp_file(char *filename, quibble_pixels qps){
                    qps.width,
                    qps.height,
                    qps.color_type,
-                   qps.colors);
+                   qps.host_data);
 }
 
 void qb_write_jpg_file(char *filename, quibble_pixels qps, int quality){
@@ -232,12 +231,12 @@ void qb_write_jpg_file(char *filename, quibble_pixels qps, int quality){
                    qps.width,
                    qps.height,
                    qps.color_type,
-                   qps.colors,
+                   qps.host_data,
                    quality);
 }
 
 void qb_free_pixels(quibble_pixels qps){
-    free(qps.colors);
+    free(qps.host_data);
 }
 
 /*----------------------------------------------------------------------------//

--- a/test/io_tests.c
+++ b/test/io_tests.c
@@ -225,9 +225,9 @@ void quibble_image_tests(void){
     quibble_pixels qps_rgb888 = qb_create_pixel_array(width,height,RGB888);
 
     quibble_color_rgba8888 *qps_rgba8888_color_array =
-        (quibble_color_rgba8888 *)qps_rgba8888.colors;
+        (quibble_color_rgba8888 *)qps_rgba8888.host_data;
     quibble_color_rgb888 *qps_rgb888_color_array =
-        (quibble_color_rgb888 *)qps_rgb888.colors;
+        (quibble_color_rgb888 *)qps_rgb888.host_data;
     qps_rgba8888_color_array[0] = test_color_rgba8888;
     qps_rgb888_color_array[0] = test_color_rgb888;
 
@@ -261,7 +261,7 @@ void quibble_image_tests(void){
                                         height,
                                         RGBA8888);
     quibble_color_rgba8888 *qps_from_file_rgba8888_colors =
-        (quibble_color_rgba8888 *)qps_from_file_rgba8888.colors;
+        (quibble_color_rgba8888 *)qps_from_file_rgba8888.host_data;
 
     quibble_pixels qps_from_file_rgb888 =
         qb_create_pixel_array_from_file("check_noalpha.png",
@@ -269,7 +269,7 @@ void quibble_image_tests(void){
                                         height,
                                         RGB888);
     quibble_color_rgb888 *qps_from_file_rgb888_colors =
-        (quibble_color_rgb888 *)qps_from_file_rgb888.colors;
+        (quibble_color_rgb888 *)qps_from_file_rgb888.host_data;
 
     quibble_pixels qps_from_jpg_rgb888 =
         qb_create_pixel_array_from_file("check_noalpha.jpg",
@@ -277,7 +277,7 @@ void quibble_image_tests(void){
                                         height,
                                         RGB888);
     quibble_color_rgb888 *qps_from_jpg_rgb888_colors =
-        (quibble_color_rgb888 *)qps_from_jpg_rgb888.colors;
+        (quibble_color_rgb888 *)qps_from_jpg_rgb888.host_data;
 
     quibble_pixels qps_from_bmp_rgb888 =
         qb_create_pixel_array_from_file("check_noalpha.bmp",
@@ -285,7 +285,7 @@ void quibble_image_tests(void){
                                         height,
                                         RGB888);
     quibble_color_rgb888 *qps_from_bmp_rgb888_colors =
-        (quibble_color_rgb888 *)qps_from_bmp_rgb888.colors;
+        (quibble_color_rgb888 *)qps_from_bmp_rgb888.host_data;
 
     quibble_pixels qps_from_none_rgb888 =
         qb_create_pixel_array_from_file("check_noalpha",
@@ -293,7 +293,7 @@ void quibble_image_tests(void){
                                         height,
                                         RGB888);
     quibble_color_rgb888 *qps_from_none_rgb888_colors =
-        (quibble_color_rgb888 *)qps_from_none_rgb888.colors;
+        (quibble_color_rgb888 *)qps_from_none_rgb888.host_data;
 
     test_value = (
         qb_color_compare_rgba8888(qps_rgba8888_color_array[0],


### PR DESCRIPTION
So, to address #22, I thought it would be good to allow for more generic image data, so the `quibble_pixels` struct now has `(void *)` data and users cast it onto `(quibble_pixel_rgba8888 *)` when they need to use it:

```
quibble_color_rgba8888 *values = (quibble_pixel *)img_array.host_data
```

This causes *some* clunkiness on the user's side when dealing with the array on the host, but...
1. Hopefully everyone's using quibble / the device to do any sort of image manipulation anyway
2. This allows for generic data types
3. We need to send a void * to the device anyway...
4. This allows me to remove unnecessary `quibble_color qb_read_color_from_rgba8888_array(unsigned char *a, int i)` functions
5. It avoids an unnecessary copy